### PR TITLE
Switch Row/Col containers to Ant Design

### DIFF
--- a/src/containers/ColContainer.js
+++ b/src/containers/ColContainer.js
@@ -1,32 +1,36 @@
 import React from 'react';
+import { Col } from 'antd';
 
-const ColContainer = ({ 
-  id, 
-  children, 
-  onDragOver, 
-  onDragLeave, 
-  onDrop, 
-  isOver, 
-  onDelete, 
-  hoverStack, 
-  handleMouseEnter, 
-  handleMouseLeave, 
-  deepestHoveredId, 
-  draggable, 
-  onDragStart, 
-  span, 
-  onComponentClick, 
-  node, 
-  path, 
-  selectedComponent 
+const ColContainer = ({
+  id,
+  children,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isOver,
+  onDelete,
+  hoverStack,
+  handleMouseEnter,
+  handleMouseLeave,
+  deepestHoveredId,
+  draggable,
+  onDragStart,
+  span,
+  onComponentClick,
+  node,
+  path,
+  selectedComponent,
+  style
 }) => {
   const isActive = hoverStack.includes(id) && deepestHoveredId === id;
   const isSelected = selectedComponent && selectedComponent.id === id;
   
   return (
-    <div 
+    <Col
       id={id}
-      className={`canvas-col${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
+      span={span}
+      data-span={span}
+      className={`canvas-col builder-col${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
@@ -34,19 +38,17 @@ const ColContainer = ({
       onMouseLeave={() => handleMouseLeave(id)}
       draggable={draggable}
       onDragStart={onDragStart}
-      data-span={span}
       onClick={(e) => {
         e.stopPropagation();
         onComponentClick(node, path);
       }}
+      style={style}
     >
-      <div className="builder-col">
-        {children}
-      </div>
+      {children}
       {onDelete && (
         <button className="delete-btn" onClick={onDelete} style={{display: isActive ? 'flex' : 'none'}}>×</button>
       )}
-    </div>
+    </Col>
   );
 };
 

--- a/src/containers/RowContainer.js
+++ b/src/containers/RowContainer.js
@@ -1,31 +1,33 @@
 import React from 'react';
+import { Row } from 'antd';
 
-const RowContainer = ({ 
-  id, 
-  children, 
-  onDragOver, 
-  onDragLeave, 
-  onDrop, 
-  isOver, 
-  onDelete, 
-  hoverStack, 
-  handleMouseEnter, 
-  handleMouseLeave, 
-  deepestHoveredId, 
-  draggable, 
-  onDragStart, 
-  onComponentClick, 
-  node, 
-  path, 
-  selectedComponent 
+const RowContainer = ({
+  id,
+  children,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isOver,
+  onDelete,
+  hoverStack,
+  handleMouseEnter,
+  handleMouseLeave,
+  deepestHoveredId,
+  draggable,
+  onDragStart,
+  onComponentClick,
+  node,
+  path,
+  selectedComponent,
+  style
 }) => {
   const isActive = hoverStack.includes(id) && deepestHoveredId === id;
   const isSelected = selectedComponent && selectedComponent.id === id;
   
   return (
-    <div 
+    <Row
       id={id}
-      className={`canvas-row${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
+      className={`canvas-row builder-row${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
@@ -37,14 +39,13 @@ const RowContainer = ({
         e.stopPropagation();
         onComponentClick(node, path);
       }}
+      style={style}
     >
-      <div className="builder-row">
-        {children}
-      </div>
+      {children}
       {onDelete && (
         <button className="delete-row-btn" onClick={onDelete} style={{display: isActive ? 'flex' : 'none'}}>×</button>
       )}
-    </div>
+    </Row>
   );
 };
 


### PR DESCRIPTION
## Summary
- swap custom row and column wrappers for Ant Design `Row` and `Col`
- support `style` prop for layout shifts

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447e60ed1c83288d1a2b99b61d91dd