### PR TITLE
Improve drag behaviour

### DIFF
--- a/src/components/NodeRenderer.js
+++ b/src/components/NodeRenderer.js
@@ -27,8 +27,8 @@ const NodeRenderer = ({
   const renderDraggedElement = () => {
     if (!isDragging || !draggedNode) return null;
     const style = {
-      left: mousePosition.x,
-      top: mousePosition.y,
+      left: mousePosition.x - draggedElementPosition.x,
+      top: mousePosition.y - draggedElementPosition.y,
     };
     return (
       <div className="dragging" style={style}>

--- a/src/hooks/useDragAndDrop.js
+++ b/src/hooks/useDragAndDrop.js
@@ -67,9 +67,16 @@ export const useDragAndDrop = (components, setComponents) => {
     setDraggedNode(null);
     setDraggedPath(null);
     setIsDragging(true);
+    const rect = e.currentTarget.getBoundingClientRect();
     setMousePosition({ x: e.clientX, y: e.clientY });
-    setDraggedElementPosition({ x: e.clientX, y: e.clientY });
+    setDraggedElementPosition({ x: e.clientX - rect.left, y: e.clientY - rect.top });
     e.dataTransfer.effectAllowed = 'move';
+    // Hide the native drag preview so our custom element is used
+    if (e.dataTransfer.setDragImage) {
+      const img = new Image();
+      img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=';
+      e.dataTransfer.setDragImage(img, 0, 0);
+    }
   };
 
   const handleExistingDragStart = (e, node, path) => {
@@ -78,9 +85,15 @@ export const useDragAndDrop = (components, setComponents) => {
     setDraggedPath(path);
     setDraggedType(null);
     setIsDragging(true);
+    const rect = e.currentTarget.getBoundingClientRect();
     setMousePosition({ x: e.clientX, y: e.clientY });
-    setDraggedElementPosition({ x: e.clientX, y: e.clientY });
+    setDraggedElementPosition({ x: e.clientX - rect.left, y: e.clientY - rect.top });
     e.dataTransfer.effectAllowed = 'move';
+    if (e.dataTransfer.setDragImage) {
+      const img = new Image();
+      img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=';
+      e.dataTransfer.setDragImage(img, 0, 0);
+    }
   };
 
   // Helper to find the candidate container and drop index


### PR DESCRIPTION
## Summary
- refine drag start logic to keep element offset during drag
- hide the browser drag image so the custom preview displays correctly
- update preview position based on stored offset

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684480d8af708328aae76ac5c8b20d9a