### PR TITLE
Add form and form item to UI builder

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -418,3 +418,28 @@ body {
   border-radius: 4px;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+/* Form containers */
+.canvas-form {
+  position: relative;
+  padding: 8px;
+  border: 1px solid #e1e4e8;
+  border-radius: 4px;
+  background-color: #fff;
+  margin-bottom: 10px;
+}
+
+.canvas-form-item {
+  position: relative;
+  padding: 8px;
+  border: 1px dashed #e1e4e8;
+  border-radius: 4px;
+  background-color: #fff;
+  margin-bottom: 8px;
+}
+
+.canvas-form.hovered > .delete-row-btn,
+.canvas-form-item.hovered > .delete-btn {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -135,15 +135,37 @@ function App() {
                 <div className="component-label">Row</div>
               </div>
 
-              <div 
-                className="component-item" 
-                draggable 
+              <div
+                className="component-item"
+                draggable
                 onDragStart={(e) => handleDragStart(e, 'col')}
               >
                 <div className="component-preview">
                   <div className="preview-placeholder"></div>
                 </div>
                 <div className="component-label">Col</div>
+              </div>
+
+              <div
+                className="component-item"
+                draggable
+                onDragStart={(e) => handleDragStart(e, 'form')}
+              >
+                <div className="component-preview">
+                  <div className="preview-placeholder"></div>
+                </div>
+                <div className="component-label">Form</div>
+              </div>
+
+              <div
+                className="component-item"
+                draggable
+                onDragStart={(e) => handleDragStart(e, 'formItem')}
+              >
+                <div className="component-preview">
+                  <div className="preview-placeholder"></div>
+                </div>
+                <div className="component-label">Form Item</div>
               </div>
 
               <div 

--- a/src/components/NodeRenderer.js
+++ b/src/components/NodeRenderer.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import RowContainer from '../containers/RowContainer';
 import ColContainer from '../containers/ColContainer';
+import FormContainer from '../containers/FormContainer';
+import FormItemContainer from '../containers/FormItemContainer';
 import { ButtonComponent, ComboBoxComponent, DatePickerComponent, TableComponent } from './BasicComponents';
+import { Input } from 'antd';
 
 const NodeRenderer = ({ 
   nodes, 
@@ -38,6 +41,8 @@ const NodeRenderer = ({
         {draggedNode.type === 'table' && <TableComponent />}
         {draggedNode.type === 'row' && <div className="preview-placeholder">Row</div>}
         {draggedNode.type === 'col' && <div className="preview-placeholder">Col</div>}
+        {draggedNode.type === 'form' && <div className="preview-placeholder">Form</div>}
+        {draggedNode.type === 'formItem' && <div className="preview-placeholder">Form.Item</div>}
       </div>
     );
   };
@@ -173,6 +178,108 @@ const NodeRenderer = ({
                 candidateDropIndex={candidateDropIndex}
               />
             </ColContainer>
+          );
+        } else if (node.type === 'form') {
+          return (
+            <FormContainer
+              key={key}
+              id={key}
+              style={shiftStyle}
+              onDragOver={(e) => handlers.handleDragOver(e, key, index)}
+              onDragLeave={() => handlers.handleDragLeave(key)}
+              onDrop={(e) => handlers.handleDrop(e, currentPath)}
+              isOver={isOver}
+              onDelete={() => handlers.handleDelete(currentPath)}
+              hoverStack={hoverStack}
+              handleMouseEnter={handleMouseEnter}
+              handleMouseLeave={handleMouseLeave}
+              deepestHoveredId={deepestHoveredId}
+              draggable
+              onDragStart={(e) => {
+                e.stopPropagation();
+                handlers.handleExistingDragStart(e, node, currentPath);
+              }}
+              onComponentClick={onComponentClick}
+              node={node}
+              path={currentPath}
+              selectedComponent={selectedComponent}
+            >
+              <NodeRenderer
+                nodes={node.children}
+                path={currentPath}
+                handlers={handlers}
+                dragOverMap={dragOverMap}
+                hoverStack={hoverStack}
+                handleMouseEnter={handleMouseEnter}
+                handleMouseLeave={handleMouseLeave}
+                deepestHoveredId={deepestHoveredId}
+                onComponentClick={onComponentClick}
+                selectedComponent={selectedComponent}
+                mousePosition={mousePosition}
+                draggedElementPosition={draggedElementPosition}
+                isDragging={isDragging}
+                draggedNode={draggedNode}
+                dragOverIndex={dragOverIndex}
+                virtualPositions={virtualPositions}
+                currentContainer={currentContainer}
+                candidateContainerId={candidateContainerId}
+                candidateDropIndex={candidateDropIndex}
+              />
+            </FormContainer>
+          );
+        } else if (node.type === 'formItem') {
+          return (
+            <FormItemContainer
+              key={key}
+              id={key}
+              label={node.props.label}
+              name={node.props.name}
+              style={shiftStyle}
+              onDragOver={(e) => handlers.handleDragOver(e, key, index)}
+              onDragLeave={() => handlers.handleDragLeave(key)}
+              onDrop={(e) => handlers.handleDrop(e, currentPath)}
+              isOver={isOver}
+              onDelete={() => handlers.handleDelete(currentPath)}
+              hoverStack={hoverStack}
+              handleMouseEnter={handleMouseEnter}
+              handleMouseLeave={handleMouseLeave}
+              deepestHoveredId={deepestHoveredId}
+              draggable
+              onDragStart={(e) => {
+                e.stopPropagation();
+                handlers.handleExistingDragStart(e, node, currentPath);
+              }}
+              onComponentClick={onComponentClick}
+              node={node}
+              path={currentPath}
+              selectedComponent={selectedComponent}
+            >
+              {node.children && node.children.length > 0 ? (
+                <NodeRenderer
+                  nodes={node.children}
+                  path={currentPath}
+                  handlers={handlers}
+                  dragOverMap={dragOverMap}
+                  hoverStack={hoverStack}
+                  handleMouseEnter={handleMouseEnter}
+                  handleMouseLeave={handleMouseLeave}
+                  deepestHoveredId={deepestHoveredId}
+                  onComponentClick={onComponentClick}
+                  selectedComponent={selectedComponent}
+                  mousePosition={mousePosition}
+                  draggedElementPosition={draggedElementPosition}
+                  isDragging={isDragging}
+                  draggedNode={draggedNode}
+                  dragOverIndex={dragOverIndex}
+                  virtualPositions={virtualPositions}
+                  currentContainer={currentContainer}
+                  candidateContainerId={candidateContainerId}
+                  candidateDropIndex={candidateDropIndex}
+                />
+              ) : (
+                <Input disabled placeholder="Input" />
+              )}
+            </FormItemContainer>
           );
         }
         // leaf components

--- a/src/components/PropertiesEditor.js
+++ b/src/components/PropertiesEditor.js
@@ -51,6 +51,25 @@ const PropertiesEditor = ({ selectedComponent, onUpdate }) => {
             />
           </div>
         );
+      case 'formItem':
+        return (
+          <>
+            <div className="property-group">
+              <label>Label</label>
+              <Input
+                value={selectedComponent.props.label}
+                onChange={(e) => handlePropertyChange('label', e.target.value)}
+              />
+            </div>
+            <div className="property-group">
+              <label>Name</label>
+              <Input
+                value={selectedComponent.props.name}
+                onChange={(e) => handlePropertyChange('name', e.target.value)}
+              />
+            </div>
+          </>
+        );
       default:
         return <div>No properties available for this component</div>;
     }

--- a/src/containers/FormContainer.js
+++ b/src/containers/FormContainer.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Form } from 'antd';
+
+const FormContainer = ({
+  id,
+  children,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isOver,
+  onDelete,
+  hoverStack,
+  handleMouseEnter,
+  handleMouseLeave,
+  deepestHoveredId,
+  draggable,
+  onDragStart,
+  onComponentClick,
+  node,
+  path,
+  selectedComponent,
+  style
+}) => {
+  const isActive = hoverStack.includes(id) && deepestHoveredId === id;
+  const isSelected = selectedComponent && selectedComponent.id === id;
+
+  return (
+    <Form
+      id={id}
+      className={`canvas-form builder-form${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onMouseEnter={() => handleMouseEnter(id)}
+      onMouseLeave={() => handleMouseLeave(id)}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onClick={(e) => {
+        e.stopPropagation();
+        onComponentClick(node, path);
+      }}
+      style={style}
+    >
+      {children}
+      {onDelete && (
+        <button className="delete-row-btn" onClick={onDelete} style={{display: isActive ? 'flex' : 'none'}}>×</button>
+      )}
+    </Form>
+  );
+};
+
+export default FormContainer;

--- a/src/containers/FormItemContainer.js
+++ b/src/containers/FormItemContainer.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Form } from 'antd';
+
+const FormItemContainer = ({
+  id,
+  children,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isOver,
+  onDelete,
+  hoverStack,
+  handleMouseEnter,
+  handleMouseLeave,
+  deepestHoveredId,
+  draggable,
+  onDragStart,
+  label,
+  name,
+  onComponentClick,
+  node,
+  path,
+  selectedComponent,
+  style
+}) => {
+  const isActive = hoverStack.includes(id) && deepestHoveredId === id;
+  const isSelected = selectedComponent && selectedComponent.id === id;
+
+  return (
+    <Form.Item
+      id={id}
+      label={label}
+      name={name}
+      className={`canvas-form-item builder-form-item${isActive ? ' hovered' : ''} ${isOver ? ' drag-over' : ''} ${isSelected ? ' selected' : ''}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      style={style}
+    >
+      <div
+        onMouseEnter={() => handleMouseEnter(id)}
+        onMouseLeave={() => handleMouseLeave(id)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onComponentClick(node, path);
+        }}
+      >
+        {children}
+      </div>
+      {onDelete && (
+        <button className="delete-btn" onClick={onDelete} style={{display: isActive ? 'flex' : 'none'}}>×</button>
+      )}
+    </Form.Item>
+  );
+};
+
+export default FormItemContainer;

--- a/src/hooks/useDragAndDrop.js
+++ b/src/hooks/useDragAndDrop.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { createNode, addNodeAtPath, removeNodeAtPath } from '../utils/treeUtils';
+import { createNode, addNodeAtPath, removeNodeAtPath, getNodeAtPath } from '../utils/treeUtils';
 
 export const useDragAndDrop = (components, setComponents) => {
   const [draggedType, setDraggedType] = useState(null);
@@ -215,6 +215,23 @@ export const useDragAndDrop = (components, setComponents) => {
   const handleDrop = (e, path) => {
     e.preventDefault();
     e.stopPropagation();
+
+    const containerNode = path.length === 0 ? { type: 'root' } : getNodeAtPath(components, path);
+
+    if ((draggedType === 'formItem' || (draggedNode && draggedNode.type === 'formItem')) && containerNode?.type !== 'form') {
+      // Form.Item can only be dropped inside a Form
+      setDragOverMap({});
+      setDraggedType(null);
+      setDraggedNode(null);
+      setDraggedPath(null);
+      setIsDragging(false);
+      setDragOverIndex(null);
+      setVirtualPositions({});
+      setCurrentContainer(null);
+      setCandidateContainerId(null);
+      setCandidateDropIndex(null);
+      return;
+    }
     
     console.log('Drop:', { 
       draggedType, 

--- a/src/utils/codeGenerator.js
+++ b/src/utils/codeGenerator.js
@@ -5,6 +5,10 @@ export const generateCode = (components) => {
       return `${spaces}<Row>\n${node.children.map(child => renderNode(child, indent + 2)).join('\n')}\n${spaces}</Row>`;
     } else if (node.type === 'col') {
       return `${spaces}<Col>\n${node.children.map(child => renderNode(child, indent + 2)).join('\n')}\n${spaces}</Col>`;
+    } else if (node.type === 'form') {
+      return `${spaces}<Form>\n${node.children.map(child => renderNode(child, indent + 2)).join('\n')}\n${spaces}</Form>`;
+    } else if (node.type === 'formItem') {
+      return `${spaces}<Form.Item label="${node.props.label}" name="${node.props.name}">\n${node.children.map(child => renderNode(child, indent + 2)).join('\n')}\n${spaces}</Form.Item>`;
     } else if (node.type === 'button') {
       return `${spaces}<button>${node.props.label}</button>`;
     } else if (node.type === 'combobox') {

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -3,6 +3,8 @@ export const createNode = (type) => {
   switch(type) {
     case 'row': return { id, type, children: [] };
     case 'col': return { id, type, children: [], span: 12 };
+    case 'form': return { id, type, children: [], props: {} };
+    case 'formItem': return { id, type, children: [], props: { label: 'Label', name: 'field' } };
     case 'button': return { id, type, props: { label: 'Button' }, children: [] };
     case 'combobox': return { id, type, props: { options: ['Option 1','Option 2','Option 3'] }, children: [] };
     case 'datepicker': return { id, type, props: {}, children: [] };
@@ -49,11 +51,20 @@ export const removeNodeAtPath = (nodes, path) => {
 export const updateNodeAtPath = (nodes, path, updatedNode) => {
   if (path.length === 0) return nodes;
   const [idx, ...rest] = path;
-  return nodes.map((node, i) => 
-    i === idx 
-      ? rest.length === 0 
-        ? updatedNode 
+  return nodes.map((node, i) =>
+    i === idx
+      ? rest.length === 0
+        ? updatedNode
         : { ...node, children: updateNodeAtPath(node.children, rest, updatedNode) }
       : node
   );
-}; 
+};
+
+export const getNodeAtPath = (nodes, path) => {
+  let current = { children: nodes };
+  for (let idx of path) {
+    if (!current.children || !current.children[idx]) return null;
+    current = current.children[idx];
+  }
+  return current;
+};


### PR DESCRIPTION
## Summary
- add new FormContainer and FormItemContainer components
- allow form and formItem nodes in the tree
- generate code for forms
- edit Form.Item properties
- restrict Form.Item drops to inside a form
- show form components in the components panel
- style form containers

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845338b95d8832888fb3e9f4098d3bb