### PR TITLE
Implement indexed node insertion for drag and drop

### DIFF
--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -21,13 +21,28 @@ export const addNodeAtPath = (nodes, path, newNode) => {
     return result;
   }
   const [idx, ...rest] = path;
-  const result = nodes.map((n, i) => 
-    i === idx 
+  const result = nodes.map((n, i) =>
+    i === idx
       ? { ...n, children: addNodeAtPath(n.children, rest, newNode) }
       : n
   );
   console.log('Added at nested level:', result);
   return result;
+};
+
+// Insert a node at a specific index among the children of the node at `path`
+export const insertNodeAtPath = (nodes, path, index, newNode) => {
+  if (path.length === 0) {
+    const result = [...nodes];
+    result.splice(index, 0, newNode);
+    return result;
+  }
+  const [idx, ...rest] = path;
+  return nodes.map((n, i) =>
+    i === idx
+      ? { ...n, children: insertNodeAtPath(n.children || [], rest, index, newNode) }
+      : n
+  );
 };
 
 export const removeNodeAtPath = (nodes, path) => {


### PR DESCRIPTION
## Summary
- add `insertNodeAtPath` utility to place a node at a specific index
- update drag-and-drop logic to compute target container from `candidateContainerId`
- drop handler uses the new insert function for both new nodes and moves

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845461109fc8328a920d501a4c9c221