### PR TITLE
Remove hardcoded translateY usage

### DIFF
--- a/src/components/NodeRenderer.js
+++ b/src/components/NodeRenderer.js
@@ -51,13 +51,6 @@ const NodeRenderer = ({
     return <div className="drop-preview" style={virtualPositions.preview} />;
   };
 
-  // Helper to get the container id for this level
-  const getContainerId = () => {
-    if (path.length === 0) return 'root';
-    // Use the last node id in the path as the container id
-    return nodes && nodes[0] && nodes[0].parentId ? nodes[0].parentId : path.join('-');
-  };
-
   return (
     <>
       {path.length === 0 && renderDraggedElement()}
@@ -71,14 +64,6 @@ const NodeRenderer = ({
         // Apply virtual positions if available
         if (virtualPositions[key]) {
           shiftStyle = { ...shiftStyle, ...virtualPositions[key] };
-        }
-
-        // Only animate siblings in the candidate container
-        const thisContainerId = getContainerId();
-        if (isDragging && candidateContainerId === thisContainerId && candidateDropIndex !== null) {
-          if (index >= candidateDropIndex) {
-            shiftStyle = { transform: 'translateY(40px)', transition: 'transform 0.2s ease-out' };
-          }
         }
 
         if (node.type === 'row') {

--- a/src/hooks/useDragAndDrop.js
+++ b/src/hooks/useDragAndDrop.js
@@ -70,30 +70,6 @@ export const useDragAndDrop = (components, setComponents) => {
     };
   }, [isDragging]);
 
-  const calculateVirtualPositions = (containerId, draggedIndex, mouseY) => {
-    const container = document.getElementById(containerId);
-    if (!container) return {};
-
-    const siblings = Array.from(container.children);
-    const positions = {};
-    
-    siblings.forEach((sibling, index) => {
-      if (index === draggedIndex) return;
-      
-      const rect = sibling.getBoundingClientRect();
-      const centerY = rect.top + rect.height / 2;
-      
-      if (mouseY < centerY && index > draggedIndex) {
-        positions[sibling.id] = { transform: 'translateY(-40px)' };
-      } else if (mouseY > centerY && index < draggedIndex) {
-        positions[sibling.id] = { transform: 'translateY(40px)' };
-      } else {
-        positions[sibling.id] = { transform: 'translateY(0)' };
-      }
-    });
-    
-    return positions;
-  };
 
   const handleDragStart = (e, type) => {
     setDraggedType(type);


### PR DESCRIPTION
## Summary
- rely on virtualPositions for all shift styles in NodeRenderer
- delete unused `calculateVirtualPositions` helper

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454f45384c832899b0e50e5499e6a2