### PR TITLE
Add Spring Batch job for file content processing

### DIFF
--- a/batch-app/pom.xml
+++ b/batch-app/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>batch-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-batch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/batch-app/src/main/java/com/example/batch/BatchApplication.java
+++ b/batch-app/src/main/java/com/example/batch/BatchApplication.java
@@ -1,0 +1,11 @@
+package com.example.batch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BatchApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BatchApplication.class, args);
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/batch/BatchConfig.java
+++ b/batch-app/src/main/java/com/example/batch/batch/BatchConfig.java
@@ -1,0 +1,122 @@
+package com.example.batch.batch;
+
+import com.example.batch.entity.HftFileContent;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.batch.core.launch.support.SimpleJobLauncher;
+import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
+import org.springframework.transaction.support.ResourcelessTransactionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableBatchProcessing
+@EnableConfigurationProperties(BatchProperties.class)
+public class BatchConfig {
+
+    private final BatchProperties properties;
+
+    public BatchConfig(BatchProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    public ResourcelessTransactionManager resourcelessTransactionManager() {
+        return new ResourcelessTransactionManager();
+    }
+
+    @Bean
+    public JobRepository jobRepository(ResourcelessTransactionManager txManager) throws Exception {
+        MapJobRepositoryFactoryBean factory = new MapJobRepositoryFactoryBean(txManager);
+        return factory.getObject();
+    }
+
+    @Bean
+    public SimpleJobLauncher jobLauncher(JobRepository jobRepository) {
+        SimpleJobLauncher launcher = new SimpleJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        return launcher;
+    }
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("batch-");
+        executor.setConcurrencyLimit(properties.getMaxThreads());
+        return executor;
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<HftFileContent> reader(EntityManagerFactory emf,
+                                             @Value("#{jobParameters['fileId']}") Long fileId,
+                                             @Value("#{jobExecutionContext['fileLogId']}") Long fileLogId,
+                                             @Value("#{stepExecutionContext['minValue']}") Long min,
+                                             @Value("#{stepExecutionContext['maxValue']}") Long max) {
+        String query = "select c from HftFileContent c where c.fileId = :fileId and c.id between :min and :max " +
+                "and c.lineNumber not in (select l.rowNumber from FileProcessLog l where l.fileLogId = :fileLogId and l.processed = 1)";
+        Map<String, Object> params = new HashMap<>();
+        params.put("fileId", fileId);
+        params.put("min", min);
+        params.put("max", max);
+        params.put("fileLogId", fileLogId);
+        return new JpaPagingItemReaderBuilder<HftFileContent>()
+                .name("hftReader")
+                .entityManagerFactory(emf)
+                .pageSize(properties.getChunkSize())
+                .queryString(query)
+                .parameterValues(params)
+                .build();
+    }
+
+    @Bean
+    public Step slaveStep(JobRepository jobRepository,
+                          PlatformTransactionManager transactionManager,
+                          ItemReader<HftFileContent> reader,
+                          ForceMajeureProcessor processor,
+                          ForceMajeureWriter writer) {
+        return new StepBuilder("slaveStep", jobRepository)
+                .<HftFileContent, ForceMajeureLoadItem>chunk(properties.getChunkSize(), transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Step masterStep(JobRepository jobRepository,
+                           PlatformTransactionManager transactionManager,
+                           Step slaveStep,
+                           HftFileContentRangePartitioner partitioner,
+                           TaskExecutor taskExecutor) {
+        return new StepBuilder("masterStep", jobRepository)
+                .partitioner(slaveStep.getName(), partitioner)
+                .step(slaveStep)
+                .gridSize(properties.getGridSize())
+                .taskExecutor(taskExecutor)
+                .build();
+    }
+
+    @Bean
+    public Job job(JobRepository jobRepository, Step masterStep, FileJobListener listener) {
+        return new JobBuilder("forceMajeureJob", jobRepository)
+                .listener(listener)
+                .start(masterStep)
+                .build();
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/batch/BatchProperties.java
+++ b/batch-app/src/main/java/com/example/batch/batch/BatchProperties.java
@@ -1,0 +1,14 @@
+package com.example.batch.batch;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.batch")
+public class BatchProperties {
+    private int chunkSize = 100;
+    private int gridSize = 1;
+    private int maxThreads = 1;
+}

--- a/batch-app/src/main/java/com/example/batch/batch/FileJobListener.java
+++ b/batch-app/src/main/java/com/example/batch/batch/FileJobListener.java
@@ -1,0 +1,46 @@
+package com.example.batch.batch;
+
+import com.example.batch.entity.FileLog;
+import com.example.batch.repository.FileLogRepository;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListenerSupport;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileJobListener extends JobExecutionListenerSupport {
+
+    private final FileLogRepository fileLogRepository;
+
+    public FileJobListener(FileLogRepository fileLogRepository) {
+        this.fileLogRepository = fileLogRepository;
+    }
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        Long fileId = jobExecution.getJobParameters().getLong("fileId");
+        FileLog log = fileLogRepository.findByFileId(fileId)
+                .orElseGet(() -> {
+                    FileLog l = new FileLog();
+                    l.setFileId(fileId);
+                    l.setFileName("FILE-" + fileId);
+                    return l;
+                });
+        log.setStatus("WAITING");
+        fileLogRepository.save(log);
+        jobExecution.getExecutionContext().putLong("fileLogId", log.getId());
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        Long fileLogId = jobExecution.getExecutionContext().getLong("fileLogId");
+        fileLogRepository.findById(fileLogId).ifPresent(log -> {
+            if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+                log.setStatus("FINISHED");
+            } else {
+                log.setStatus("ERROR");
+            }
+            fileLogRepository.save(log);
+        });
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/batch/ForceMajeureLoadItem.java
+++ b/batch-app/src/main/java/com/example/batch/batch/ForceMajeureLoadItem.java
@@ -1,0 +1,13 @@
+package com.example.batch.batch;
+
+import com.example.batch.entity.ForceMajeureLoad;
+import com.example.batch.entity.HftFileContent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ForceMajeureLoadItem {
+    private final HftFileContent source;
+    private final ForceMajeureLoad target;
+}

--- a/batch-app/src/main/java/com/example/batch/batch/ForceMajeureProcessor.java
+++ b/batch-app/src/main/java/com/example/batch/batch/ForceMajeureProcessor.java
@@ -1,0 +1,71 @@
+package com.example.batch.batch;
+
+import com.example.batch.entity.ForceMajeureLoad;
+import com.example.batch.entity.HftFileContent;
+import com.example.batch.entity.FileProcessErrorLog;
+import com.example.batch.entity.FileProcessLog;
+import com.example.batch.repository.FileLogRepository;
+import com.example.batch.repository.FileProcessErrorLogRepository;
+import com.example.batch.repository.FileProcessLogRepository;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+
+@Component
+@StepScope
+public class ForceMajeureProcessor implements ItemProcessor<HftFileContent, ForceMajeureLoadItem> {
+
+    private final FileLogRepository fileLogRepository;
+    private final FileProcessLogRepository fileProcessLogRepository;
+    private final FileProcessErrorLogRepository errorLogRepository;
+
+    @Value("#{jobParameters['fileId']}")
+    private Long fileId;
+
+    public ForceMajeureProcessor(FileLogRepository fileLogRepository,
+                                 FileProcessLogRepository fileProcessLogRepository,
+                                 FileProcessErrorLogRepository errorLogRepository) {
+        this.fileLogRepository = fileLogRepository;
+        this.fileProcessLogRepository = fileProcessLogRepository;
+        this.errorLogRepository = errorLogRepository;
+    }
+
+    @Override
+    public ForceMajeureLoadItem process(HftFileContent item) {
+        Long fileLogId = fileLogRepository.findByFileId(fileId).map(f -> f.getId()).orElse(null);
+        try {
+            String[] parts = item.getContent().split(",");
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            ForceMajeureLoad load = new ForceMajeureLoad();
+            load.setHftFileId(item.getFileId());
+            load.setVknTckn(parts[0]);
+            load.setForceMajeureNftYear(Integer.valueOf(parts[1]));
+            load.setForceMajeureNftMonth(Integer.valueOf(parts[2]));
+            load.setForceMajeureNftCode(Integer.valueOf(parts[3]));
+            load.setForceMajeureStartDate(sdf.parse(parts[4]));
+            load.setForceMajeureEndDate(sdf.parse(parts[5]));
+            load.setPersonCode(parts[6]);
+            load.setFirmName(parts[7]);
+            load.setFirstName(parts[8]);
+            load.setCustomerMiddleName(parts[9]);
+            load.setCustomerSurname(parts[10]);
+            return new ForceMajeureLoadItem(item, load);
+        } catch (Exception e) {
+            FileProcessLog log = new FileProcessLog();
+            log.setFileLogId(fileLogId);
+            log.setRowNumber(item.getLineNumber());
+            log.setProcessed(0);
+            fileProcessLogRepository.save(log);
+            FileProcessErrorLog errorLog = new FileProcessErrorLog();
+            errorLog.setFileProcessLogId(log.getId());
+            errorLog.setErrorMessage(e.getMessage());
+            errorLog.setErrorStackTrace(ExceptionUtils.getStackTrace(e));
+            errorLogRepository.save(errorLog);
+            return null;
+        }
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/batch/ForceMajeureWriter.java
+++ b/batch-app/src/main/java/com/example/batch/batch/ForceMajeureWriter.java
@@ -1,0 +1,61 @@
+package com.example.batch.batch;
+
+import com.example.batch.entity.FileProcessErrorLog;
+import com.example.batch.entity.FileProcessLog;
+import com.example.batch.repository.FileLogRepository;
+import com.example.batch.repository.FileProcessErrorLogRepository;
+import com.example.batch.repository.FileProcessLogRepository;
+import com.example.batch.repository.ForceMajeureLoadRepository;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@StepScope
+public class ForceMajeureWriter implements ItemWriter<ForceMajeureLoadItem> {
+
+    private final ForceMajeureLoadRepository loadRepository;
+    private final FileProcessLogRepository processLogRepository;
+    private final FileProcessErrorLogRepository errorLogRepository;
+    private final FileLogRepository fileLogRepository;
+
+    @Value("#{jobParameters['fileId']}")
+    private Long fileId;
+
+    public ForceMajeureWriter(ForceMajeureLoadRepository loadRepository,
+                              FileProcessLogRepository processLogRepository,
+                              FileProcessErrorLogRepository errorLogRepository,
+                              FileLogRepository fileLogRepository) {
+        this.loadRepository = loadRepository;
+        this.processLogRepository = processLogRepository;
+        this.errorLogRepository = errorLogRepository;
+        this.fileLogRepository = fileLogRepository;
+    }
+
+    @Override
+    public void write(List<? extends ForceMajeureLoadItem> items) {
+        Long fileLogId = fileLogRepository.findByFileId(fileId).map(f -> f.getId()).orElse(null);
+        for (ForceMajeureLoadItem item : items) {
+            FileProcessLog log = new FileProcessLog();
+            log.setFileLogId(fileLogId);
+            log.setRowNumber(item.getSource().getLineNumber());
+            try {
+                loadRepository.save(item.getTarget());
+                log.setProcessed(1);
+                processLogRepository.save(log);
+            } catch (Exception e) {
+                log.setProcessed(0);
+                processLogRepository.save(log);
+                FileProcessErrorLog errorLog = new FileProcessErrorLog();
+                errorLog.setFileProcessLogId(log.getId());
+                errorLog.setErrorMessage(e.getMessage());
+                errorLog.setErrorStackTrace(ExceptionUtils.getStackTrace(e));
+                errorLogRepository.save(errorLog);
+            }
+        }
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/batch/HftFileContentRangePartitioner.java
+++ b/batch-app/src/main/java/com/example/batch/batch/HftFileContentRangePartitioner.java
@@ -1,0 +1,48 @@
+package com.example.batch.batch;
+
+import com.example.batch.repository.HftFileContentRepository;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.partition.support.Partitioner;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@StepScope
+public class HftFileContentRangePartitioner implements Partitioner {
+
+    private final HftFileContentRepository repository;
+
+    @Value("#{jobParameters['fileId']}")
+    private Long fileId;
+
+    public HftFileContentRangePartitioner(HftFileContentRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Map<String, ExecutionContext> partition(int gridSize) {
+        Long min = repository.findMinIdByFileId(fileId);
+        Long max = repository.findMaxIdByFileId(fileId);
+        Map<String, ExecutionContext> result = new HashMap<>();
+        if (min == null || max == null) {
+            return result;
+        }
+        long range = (max - min) / gridSize + 1;
+        long start = min;
+        long end = start + range - 1;
+
+        for (int i = 0; i < gridSize && start <= max; i++) {
+            ExecutionContext value = new ExecutionContext();
+            value.putLong("minValue", start);
+            value.putLong("maxValue", Math.min(end, max));
+            result.put("partition" + i, value);
+            start += range;
+            end += range;
+        }
+        return result;
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/entity/FileLog.java
+++ b/batch-app/src/main/java/com/example/batch/entity/FileLog.java
@@ -1,0 +1,28 @@
+package com.example.batch.entity;
+
+import com.example.batch.entity.base.UpdateDateBaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "FILE_LOG")
+public class FileLog extends UpdateDateBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "FILE_LOG_GENERATOR")
+    @SequenceGenerator(name = "FILE_LOG_GENERATOR", sequenceName = "SEQ_FILE_LOG", allocationSize = 1000)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    @Column(name = "FILE_ID")
+    private Long fileId;
+    @Column(name = "FILE_NAME")
+    private String fileName;
+    @Column(name = "STATUS")
+    private String status;
+}

--- a/batch-app/src/main/java/com/example/batch/entity/FileProcessErrorLog.java
+++ b/batch-app/src/main/java/com/example/batch/entity/FileProcessErrorLog.java
@@ -1,0 +1,30 @@
+package com.example.batch.entity;
+
+import com.example.batch.entity.base.CreateDateBaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "FILE_PROCESS_ERROR_LOG")
+public class FileProcessErrorLog extends CreateDateBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "FILE_PROCESS_ERROR_LOG_GENERATOR")
+    @SequenceGenerator(name = "FILE_PROCESS_ERROR_LOG_GENERATOR", sequenceName = "SEQ_FILE_PROCESS_ERROR_LOG", allocationSize = 1000)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    @Column(name = "FILE_PROCESS_LOG_ID")
+    private Long fileProcessLogId;
+    @Column(name = "EXCEPTION_ID")
+    private Long exceptionId;
+    @Column(name = "ERROR_MESSAGE")
+    private String errorMessage;
+    @Column(name = "ERROR_STACK_TRACE")
+    private String errorStackTrace;
+}

--- a/batch-app/src/main/java/com/example/batch/entity/FileProcessLog.java
+++ b/batch-app/src/main/java/com/example/batch/entity/FileProcessLog.java
@@ -1,0 +1,27 @@
+package com.example.batch.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "FILE_PROCESS_LOG")
+public class FileProcessLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "FILE_PROCESS_LOG_GENERATOR")
+    @SequenceGenerator(name = "FILE_PROCESS_LOG_GENERATOR", sequenceName = "SEQ_FILE_PROCESS_LOG", allocationSize = 1000)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    @Column(name = "ROWNUMBER")
+    private Long rowNumber;
+    @Column(name = "PROCESSED")
+    private int processed;
+    @Column(name = "FILE_LOG_ID")
+    private Long fileLogId;
+}

--- a/batch-app/src/main/java/com/example/batch/entity/ForceMajeureLoad.java
+++ b/batch-app/src/main/java/com/example/batch/entity/ForceMajeureLoad.java
@@ -1,0 +1,48 @@
+package com.example.batch.entity;
+
+import com.example.batch.entity.base.CreateDateBaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "FORCE_MAJEURE_LOAD")
+public class ForceMajeureLoad extends CreateDateBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "FORCE_MAJEURE_LOAD_GENERATOR")
+    @SequenceGenerator(name = "FORCE_MAJEURE_LOAD_GENERATOR", sequenceName = "SEQ_FORCE_MAJEURE_LOAD", allocationSize = 1000)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    @Column(name = "HFT_FILE_ID")
+    private Long hftFileId;
+    @Column(name = "VKN_TCKN")
+    private String vknTckn;
+    @Column(name = "FORCE_MAJEURE_NTF_YEAR")
+    private Integer forceMajeureNftYear;
+    @Column(name = "FORCE_MAJEURE_NTF_MONTH")
+    private Integer forceMajeureNftMonth;
+    @Column(name = "FORCE_MAJEURE_NTF_CODE")
+    private Integer forceMajeureNftCode;
+    @Column(name = "FORCE_MAJEURE_START_DATE")
+    private Date forceMajeureStartDate;
+    @Column(name = "FORCE_MAJEURE_END_DATE")
+    private Date forceMajeureEndDate;
+    @Column(name = "PERSON_CODE")
+    private String personCode;
+    @Column(name = "FIRM_NAME")
+    private String firmName;
+    @Column(name = "FIRST_NAME")
+    private String firstName;
+    @Column(name = "CUSTOMER_MIDDLE_NAME")
+    private String customerMiddleName;
+    @Column(name = "CUSTOMER_SURNAME")
+    private String customerSurname;
+}

--- a/batch-app/src/main/java/com/example/batch/entity/HftFileContent.java
+++ b/batch-app/src/main/java/com/example/batch/entity/HftFileContent.java
@@ -1,0 +1,31 @@
+package com.example.batch.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "HFT_FILE_CONTENT")
+public class HftFileContent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "HFT_FILE_CONTENT_GENERATOR")
+    @SequenceGenerator(name = "HFT_FILE_CONTENT_GENERATOR", sequenceName = "HFT_FILE_CONTENT_LOAD", allocationSize = 1)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    @Column(name = "INSERT_DATE")
+    private Date insertDate;
+    @Column(name = "FILE_ID", nullable = false)
+    private Long fileId;
+    @Column(name = "LINE_NUMBER")
+    private Long lineNumber;
+    @Column(name = "CONTENT")
+    private String content;
+}

--- a/batch-app/src/main/java/com/example/batch/entity/base/CreateDateBaseEntity.java
+++ b/batch-app/src/main/java/com/example/batch/entity/base/CreateDateBaseEntity.java
@@ -1,0 +1,23 @@
+package com.example.batch.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class CreateDateBaseEntity {
+
+    @Column(name = "CREATE_DATE")
+    private Date createDate;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createDate = new Date();
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/entity/base/UpdateDateBaseEntity.java
+++ b/batch-app/src/main/java/com/example/batch/entity/base/UpdateDateBaseEntity.java
@@ -1,0 +1,25 @@
+package com.example.batch.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class UpdateDateBaseEntity extends CreateDateBaseEntity {
+
+    @Column(name = "UPDATE_DATE")
+    private Date updateDate;
+
+    @PrePersist
+    @PreUpdate
+    protected void onUpdate() {
+        this.updateDate = new Date();
+    }
+}

--- a/batch-app/src/main/java/com/example/batch/repository/FileLogRepository.java
+++ b/batch-app/src/main/java/com/example/batch/repository/FileLogRepository.java
@@ -1,0 +1,10 @@
+package com.example.batch.repository;
+
+import com.example.batch.entity.FileLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FileLogRepository extends JpaRepository<FileLog, Long> {
+    Optional<FileLog> findByFileId(Long fileId);
+}

--- a/batch-app/src/main/java/com/example/batch/repository/FileProcessErrorLogRepository.java
+++ b/batch-app/src/main/java/com/example/batch/repository/FileProcessErrorLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.batch.repository;
+
+import com.example.batch.entity.FileProcessErrorLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileProcessErrorLogRepository extends JpaRepository<FileProcessErrorLog, Long> {
+}

--- a/batch-app/src/main/java/com/example/batch/repository/FileProcessLogRepository.java
+++ b/batch-app/src/main/java/com/example/batch/repository/FileProcessLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.batch.repository;
+
+import com.example.batch.entity.FileProcessLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileProcessLogRepository extends JpaRepository<FileProcessLog, Long> {
+}

--- a/batch-app/src/main/java/com/example/batch/repository/ForceMajeureLoadRepository.java
+++ b/batch-app/src/main/java/com/example/batch/repository/ForceMajeureLoadRepository.java
@@ -1,0 +1,7 @@
+package com.example.batch.repository;
+
+import com.example.batch.entity.ForceMajeureLoad;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ForceMajeureLoadRepository extends JpaRepository<ForceMajeureLoad, Long> {
+}

--- a/batch-app/src/main/java/com/example/batch/repository/HftFileContentRepository.java
+++ b/batch-app/src/main/java/com/example/batch/repository/HftFileContentRepository.java
@@ -1,0 +1,24 @@
+package com.example.batch.repository;
+
+import com.example.batch.entity.HftFileContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface HftFileContentRepository extends JpaRepository<HftFileContent, Long> {
+
+    @Query("select min(c.id) from HftFileContent c where c.fileId = :fileId")
+    Long findMinIdByFileId(@Param("fileId") Long fileId);
+
+    @Query("select max(c.id) from HftFileContent c where c.fileId = :fileId")
+    Long findMaxIdByFileId(@Param("fileId") Long fileId);
+
+    @Query("select c from HftFileContent c where c.fileId = :fileId and c.id between :start and :end " +
+           "and c.lineNumber not in (select l.rowNumber from FileProcessLog l where l.fileLogId = :fileLogId and l.processed = 1)")
+    List<HftFileContent> findUnprocessedInRange(@Param("fileId") Long fileId,
+                                                @Param("fileLogId") Long fileLogId,
+                                                @Param("start") Long start,
+                                                @Param("end") Long end);
+}

--- a/batch-app/src/main/resources/application.yml
+++ b/batch-app/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+  batch:
+    jdbc:
+      initialize-schema: never
+app:
+  batch:
+    chunk-size: 50
+    grid-size: 4
+    max-threads: 4


### PR DESCRIPTION
## Summary
- add Spring Batch configuration using in-memory job repository
- implement RangePartitioner and multi-threaded step with thread counts from YAML
- parse file rows into ForceMajeureLoad records and log processing status/errors

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c04dca3bf48328a6d808bcf233bddc